### PR TITLE
Enhanced Diagnostic and State Storage Module

### DIFF
--- a/diagnostic-settings/diagnostic.tf
+++ b/diagnostic-settings/diagnostic.tf
@@ -1,4 +1,5 @@
 resource "azurerm_monitor_diagnostic_setting" "diagnostic" {
+  provider                       = azurerm.target
   count                          = local.set_diagnostic_settings
   name                           = var.diagnostic_name
   target_resource_id             = var.target_resource_id

--- a/diagnostic-settings/loganalytics.tf
+++ b/diagnostic-settings/loganalytics.tf
@@ -6,10 +6,7 @@ data "azurerm_resource_group" "log_resource_group" {
 
 # get log analytics workspace
 data "azurerm_log_analytics_workspace" "main" {
-  provider = azurerm.log_analytics
-  depends_on = [
-    data.azurerm_resource_group.log_resource_group
-  ]
+  provider            = azurerm.log_analytics
   name                = var.log_analytics_name
   resource_group_name = data.azurerm_resource_group.log_resource_group.name
 }

--- a/diagnostic-settings/meta.tf
+++ b/diagnostic-settings/meta.tf
@@ -1,5 +1,10 @@
 data "azurerm_monitor_diagnostic_categories" "diag" {
+  provider    = azurerm.target
   resource_id = var.target_resource_id
+}
+
+data "azurerm_subscription" "log_analytics" {
+  provider = azurerm.log_analytics
 }
 
 locals {

--- a/diagnostic-settings/providers.tf
+++ b/diagnostic-settings/providers.tf
@@ -1,9 +1,12 @@
 terraform {
   required_providers {
     azurerm = {
-      source                = "hashicorp/azurerm"
-      version               = ">=4.0"
-      configuration_aliases = [azurerm.log_analytics]
+      source  = "hashicorp/azurerm"
+      version = ">=4.0"
+      configuration_aliases = [
+        azurerm.log_analytics,
+        azurerm.target
+      ]
     }
   }
 }

--- a/diagnostic-settings/variables.tf
+++ b/diagnostic-settings/variables.tf
@@ -6,11 +6,7 @@ variable "target_resource_id" {
 variable "enabled" {
   description = "value to enable or disable the diagnostic settings"
   type        = bool
-}
-
-variable "log_analytics_subscription" {
-  description = "Subscription id of the log analytics workspace"
-  type        = string
+  default     = true
 }
 
 variable "log_analytics_resource_group" {

--- a/main-resource-group/diag.tf
+++ b/main-resource-group/diag.tf
@@ -1,9 +1,14 @@
 # Monitoring Key Vault
 module "monitoring_key_vault" {
-  enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings"
+  count = var.use_diagnostic_settings ? 1 : 0
+  providers = {
+    azurerm.target        = azurerm,
+    azurerm.log_analytics = azurerm.log_analytics
+  }
+
+  source = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
+
   target_resource_id           = azurerm_key_vault.main.id
   log_analytics_name           = var.log_analytics_name
-  log_analytics_subscription   = var.log_analytics_subscription
   log_analytics_resource_group = var.log_analytics_resource_group
 }

--- a/main-resource-group/diag.tf
+++ b/main-resource-group/diag.tf
@@ -6,7 +6,7 @@ module "monitoring_key_vault" {
     azurerm.log_analytics = azurerm.log_analytics
   }
 
-  source = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
+  source = "github.com/drpfleger/terraform/diagnostic-settings"
 
   target_resource_id           = azurerm_key_vault.main.id
   log_analytics_name           = var.log_analytics_name

--- a/main-resource-group/providers.tf
+++ b/main-resource-group/providers.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>4.12.0"
+      version = ">=4.0"
     }
     azuread = {
-      version = "~>3.0.0"
+      version = ">=3.0"
     }
   }
 }

--- a/main-resource-group/providers.tf
+++ b/main-resource-group/providers.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>4.00.0"
+      version = "~>4.12.0"
     }
     azuread = {
-      version = "~>2.53.0"
+      version = "~>3.0.0"
     }
   }
 }
@@ -19,3 +19,8 @@ provider "azurerm" {
   subscription_id = var.subscription_id
 }
 
+provider "azurerm" {
+  alias           = "log_analytics"
+  subscription_id = var.log_analytics_subscription == "" ? var.subscription_id : var.log_analytics_subscription
+  features {}
+}

--- a/main-resource-group/variables.tf
+++ b/main-resource-group/variables.tf
@@ -77,18 +77,30 @@ variable "log_analytics_name" {
 
   validation {
     condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_name != "")
-    error_message = "log_analytics_name is required if use_diagnostic_settings is true"
+    error_message = "log_analytics_name is mandatory if use_diagnostic_settings is set to true"
   }
 }
 
 variable "log_analytics_subscription" {
   description = "Subscription id of the log analytics workspace"
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_subscription != "")
+    error_message = "log_analytics_subscription is mandatory if use_diagnostic_settings is set to true"
+  }
 }
 
 variable "log_analytics_resource_group" {
   description = "Resource group of the log analytics workspace"
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_resource_group != "")
+    error_message = "log_analytics_resource_group is mandatory if use_diagnostic_settings is set to true"
+  }
 }
 
 variable "subscription_id" {

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,15 @@
 # Sample Usage of the Diagnostic Settings Module
 
-```hcl
-provider "azurerm" {
-    features {
-        key_vault {
-            purge_soft_delete_on_destroy = true
-        }
-    }
-    subscription_id = "00000000-0000-0000-0000-000000000000"
-}
-```
+### General Information
+
+In Terraform, providers are responsible for managing the lifecycle of resources. When using modules,
+you can pass providers explicitly to ensure that the module uses the correct provider configurations.
+
+For more information, refer to the Terraform [documentation](https://developer.hashicorp.com/terraform/language/modules/develop/providers#passing-providers-explicitly).
+
+The `azurerm` provider is configured with the subscription ID where the target resources will be created. An aliased `azurerm` provider, named `log_analytics`, is configured with the subscription ID where the Log Analytics Workspace resides. These providers are then injected into the monitoring module to ensure the resources are created and managed in the correct subscriptions.
+
+---
 
 ### Define Log Analytics Workspace
 
@@ -38,17 +38,35 @@ resource "azurerm_storage_account" "smpl" {
 }
 ```
 
+### Define providers for your module and the Log Analytics Workspace
+
+```hcl
+provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  features {}
+}
+
+provider "azurerm" {
+  alias = "log_analytics"
+  subscription_id =     "00000000-0000-0000-0000-000000000000"
+  features {}
+}
+
+```
+
 ### Create Diagnostic Settings with _ALL_ Categories and Metrics for Storage Account
 
 ```hcl
 module "diag_storage" {
     source = "../diagnostic-settings"
 
-    target_resource_id = azurerm_storage_account.smpl.id
-    enabled            = true
+    providers = {
+        azurerm.target        = azurerm,
+        azurerm.log_analytics = azurerm.log_analytics
+    }
 
+    target_resource_id           = azurerm_storage_account.smpl.id
     log_analytics_name           = local.log_analytics_name
-    log_analytics_subscription   = local.log_analytics_subscription
     log_analytics_resource_group = local.log_analytics_resource_group
 
 }
@@ -58,12 +76,15 @@ module "diag_storage" {
 
 ```hcl
 module "diag_container_blob" {
-source = "../diagnostic-settings"
-enabled = true
-target_resource_id = "${azurerm_storage_account.smpl.id}/blobServices/default/"
+    source = "../diagnostic-settings"
 
+    providers = {
+        azurerm.target        = azurerm,
+        azurerm.log_analytics = azurerm.log_analytics
+    }
+
+    target_resource_id = "${azurerm_storage_account.smpl.id}/blobServices/default/"
     log_analytics_name           = local.log_analytics_name
-    log_analytics_subscription   = local.log_analytics_subscription
     log_analytics_resource_group = local.log_analytics_resource_group
 
     user_defined_category_groups = ["audit"]
@@ -76,10 +97,14 @@ target_resource_id = "${azurerm_storage_account.smpl.id}/blobServices/default/"
 
 ```hcl
 module "diag_container_queue" {
-source = "../diagnostic-settings"
-enabled = true
-target_resource_id = "${azurerm_storage_account.smpl.id}/queueServices/default/"
+    source = "../diagnostic-settings"
 
+    providers = {
+        azurerm.target        = azurerm,
+        azurerm.log_analytics = azurerm.log_analytics
+    }
+
+    target_resource_id = "${azurerm_storage_account.smpl.id}/queueServices/default/"
     log_analytics_name           = local.log_analytics_name
     log_analytics_subscription   = local.log_analytics_subscription
     log_analytics_resource_group = local.log_analytics_resource_group

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -4,7 +4,7 @@ module "monitoring_state_storage" {
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
-  log_analytics_subscription   = var.log_analytics_subscription
+  log_analytics_subscription   = var.use_diagnostic_settings ? var.log_analytics_subscription : var.subscription_id
   log_analytics_resource_group = var.log_analytics_resource_group
 }
 
@@ -14,6 +14,6 @@ module "monitoring_state_blob" {
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name
-  log_analytics_subscription   = var.log_analytics_subscription
+  log_analytics_subscription   = var.use_diagnostic_settings ? var.log_analytics_subscription : var.subscription_id
   log_analytics_resource_group = var.log_analytics_resource_group
 }

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -6,6 +6,7 @@ module "monitoring_state_storage" {
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
   log_analytics_resource_group = var.log_analytics_resource_group
+  subscription_id              = var.subscription_id
 }
 
 # BlobService
@@ -16,4 +17,5 @@ module "monitoring_state_blob" {
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
   log_analytics_resource_group = var.log_analytics_resource_group
+  subscription_id              = var.subscription_id
 }

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -1,21 +1,25 @@
 ## State Storage
 module "monitoring_state_storage" {
+  providers = {
+    azurerm.target        = azurerm,
+    azurerm.log_analytics = azurerm.log_analytics
+  }
   count                        = var.use_diagnostic_settings ? 1 : 0
-  enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
-  log_analytics_subscription   = var.use_diagnostic_settings ? var.log_analytics_subscription : var.subscription_id
   log_analytics_resource_group = var.log_analytics_resource_group
 }
 
 # BlobService
 module "monitoring_state_blob" {
+  providers = {
+    azurerm.target        = azurerm,
+    azurerm.log_analytics = azurerm.log_analytics
+  }
   count                        = var.use_diagnostic_settings ? 1 : 0
-  enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name
-  log_analytics_subscription   = var.use_diagnostic_settings ? var.log_analytics_subscription : var.subscription_id
   log_analytics_resource_group = var.log_analytics_resource_group
 }

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -6,7 +6,6 @@ module "monitoring_state_storage" {
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
   log_analytics_resource_group = var.log_analytics_resource_group
-  subscription_id              = var.subscription_id
 }
 
 # BlobService
@@ -17,5 +16,4 @@ module "monitoring_state_blob" {
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
   log_analytics_resource_group = var.log_analytics_resource_group
-  subscription_id              = var.subscription_id
 }

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -6,7 +6,7 @@ module "monitoring_state_storage" {
     azurerm.log_analytics = azurerm.log_analytics
   }
 
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
   log_analytics_resource_group = var.log_analytics_resource_group
@@ -21,7 +21,7 @@ module "monitoring_state_blob" {
     azurerm.log_analytics = azurerm.log_analytics
   }
 
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name
   log_analytics_resource_group = var.log_analytics_resource_group

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -1,7 +1,7 @@
 ## State Storage
 module "monitoring_state_storage" {
   enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnostic-settings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
@@ -11,7 +11,7 @@ module "monitoring_state_storage" {
 # BlobService
 module "monitoring_state_blob" {
   enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnostic-settings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -1,7 +1,7 @@
 ## State Storage
 module "monitoring_state_storage" {
   enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnostic-settings"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription
@@ -11,7 +11,7 @@ module "monitoring_state_storage" {
 # BlobService
 module "monitoring_state_blob" {
   enabled                      = var.use_diagnostic_settings
-  source                       = "github.com/drpfleger/terraform/diagnostic-settings"
+  source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnostic-settings"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name
   log_analytics_subscription   = var.log_analytics_subscription

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -1,10 +1,11 @@
 ## State Storage
 module "monitoring_state_storage" {
+  count = var.use_diagnostic_settings ? 1 : 0
   providers = {
     azurerm.target        = azurerm,
     azurerm.log_analytics = azurerm.log_analytics
   }
-  count                        = var.use_diagnostic_settings ? 1 : 0
+
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
   target_resource_id           = azurerm_storage_account.main.id
   log_analytics_name           = var.log_analytics_name
@@ -13,11 +14,13 @@ module "monitoring_state_storage" {
 
 # BlobService
 module "monitoring_state_blob" {
+  count = var.use_diagnostic_settings ? 1 : 0
+
   providers = {
     azurerm.target        = azurerm,
     azurerm.log_analytics = azurerm.log_analytics
   }
-  count                        = var.use_diagnostic_settings ? 1 : 0
+
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=statestorage"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"
   log_analytics_name           = var.log_analytics_name

--- a/state-storage/diag.tf
+++ b/state-storage/diag.tf
@@ -1,5 +1,6 @@
 ## State Storage
 module "monitoring_state_storage" {
+  count                        = var.use_diagnostic_settings ? 1 : 0
   enabled                      = var.use_diagnostic_settings
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = azurerm_storage_account.main.id
@@ -10,6 +11,7 @@ module "monitoring_state_storage" {
 
 # BlobService
 module "monitoring_state_blob" {
+  count                        = var.use_diagnostic_settings ? 1 : 0
   enabled                      = var.use_diagnostic_settings
   source                       = "github.com/drpfleger/terraform/diagnostic-settings?ref=diagnosticsettings"
   target_resource_id           = "${azurerm_storage_account.main.id}/blobServices/default/"

--- a/state-storage/providers.tf
+++ b/state-storage/providers.tf
@@ -16,5 +16,5 @@ provider "azurerm" {
 provider "azurerm" {
   alias = "log_analytics"
   features {}
-  subscription_id = var.log_analytics_subscription
+  subscription_id = var.log_analytics_subscription == "" ? var.subscription_id : var.log_analytics_subscription
 }

--- a/state-storage/providers.tf
+++ b/state-storage/providers.tf
@@ -7,14 +7,12 @@ terraform {
 }
 
 provider "azurerm" {
-  features {
-  }
-
   subscription_id = var.subscription_id
+  features {}
 }
 
 provider "azurerm" {
-  alias = "log_analytics"
-  features {}
+  alias           = "log_analytics"
   subscription_id = var.log_analytics_subscription == "" ? var.subscription_id : var.log_analytics_subscription
+  features {}
 }

--- a/state-storage/providers.tf
+++ b/state-storage/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>4.00.0"
+      version = "~>4.12.0"
     }
   }
 }

--- a/state-storage/providers.tf
+++ b/state-storage/providers.tf
@@ -12,3 +12,9 @@ provider "azurerm" {
 
   subscription_id = var.subscription_id
 }
+
+provider "azurerm" {
+  alias = "log_analytics"
+  features {}
+  subscription_id = var.log_analytics_subscription
+}

--- a/state-storage/providers.tf
+++ b/state-storage/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     azurerm = {
-      version = "~>4.12.0"
+      version = ">=4.0"
     }
   }
 }

--- a/state-storage/storage.tf
+++ b/state-storage/storage.tf
@@ -12,6 +12,6 @@ resource "azurerm_storage_account" "main" {
 
 # create storage container
 resource "azurerm_storage_container" "state" {
-  name                 = local.container_name
-  storage_account_name = azurerm_storage_account.main.name
+  name               = local.container_name
+  storage_account_id = azurerm_storage_account.main.id
 }

--- a/state-storage/variables.tf
+++ b/state-storage/variables.tf
@@ -33,6 +33,11 @@ variable "use_diagnostic_settings" {
 variable "log_analytics_name" {
   description = "Name of the log analytics workspace"
   type        = string
+
+  validation {
+    condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_name != "")
+    error_message = "log_analytics_name is mandatory if use_diagnostic_settings is set to true"
+  }
 }
 
 variable "log_analytics_subscription" {

--- a/state-storage/variables.tf
+++ b/state-storage/variables.tf
@@ -33,6 +33,7 @@ variable "use_diagnostic_settings" {
 variable "log_analytics_name" {
   description = "Name of the log analytics workspace"
   type        = string
+  default     = ""
 
   validation {
     condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_name != "")

--- a/state-storage/variables.tf
+++ b/state-storage/variables.tf
@@ -44,11 +44,23 @@ variable "log_analytics_name" {
 variable "log_analytics_subscription" {
   description = "Subscription id of the log analytics workspace"
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_subscription != "")
+    error_message = "log_analytics_subscription is mandatory if use_diagnostic_settings is set to true"
+  }
 }
 
 variable "log_analytics_resource_group" {
   description = "Resource group of the log analytics workspace"
   type        = string
+  default     = ""
+
+  validation {
+    condition     = var.use_diagnostic_settings == false || (var.use_diagnostic_settings == true && var.log_analytics_resource_group != "")
+    error_message = "log_analytics_resource_group is mandatory if use_diagnostic_settings is set to true"
+  }
 }
 
 variable "subscription_id" {


### PR DESCRIPTION
## Monitoring
It's now possible to use `Count` for the Monitoring Module in your Project. 

## State Storage
It is now possible to skip the monitoring of the state storage. Previously, you had to specify information for the log analytics workspace, even if you did not want to monitor it at all. #