### PR TITLE
Service App enhancements

### DIFF
--- a/service-app/meta.tf
+++ b/service-app/meta.tf
@@ -6,10 +6,10 @@ data "azuread_service_principal" "apis" {
   client_id = each.value.api_client_id
 }
 
-# read key vault of this project + stage
+# read the given key vault to store secrets
 data "azurerm_key_vault" "main" {
-  name                = local.kvt_name
-  resource_group_name = local.rg_name
+  name                = var.kvt_name
+  resource_group_name = var.rg_name
 }
 
 # read this projects admin group name

--- a/service-app/meta.tf
+++ b/service-app/meta.tf
@@ -10,8 +10,8 @@ data "azuread_service_principal" "apis" {
 # set to default value in naming if not differently set in module call
 # Goal is not having to set values in most cases, only edge cases where naming conventions are not followed
 data "azurerm_key_vault" "main" {
-  name                = var.kvt_name != "default" ? var.kvt_name : local.default_kvt_name
-  resource_group_name = var.rg_name != "default" ? var.rg_name : local.default_rg_name
+  name                = var.kvt_name != null ? var.kvt_name : local.default_kvt_name
+  resource_group_name = var.rg_name != null ? var.rg_name : local.default_rg_name
 }
 
 # read this projects admin group name

--- a/service-app/meta.tf
+++ b/service-app/meta.tf
@@ -7,9 +7,11 @@ data "azuread_service_principal" "apis" {
 }
 
 # read the given key vault to store secrets
+# set to default value in naming if not differently set in module call
+# Goal is not having to set values in most cases, only edge cases where naming conventions are not followed
 data "azurerm_key_vault" "main" {
-  name                = var.kvt_name
-  resource_group_name = var.rg_name
+  name                = var.kvt_name != "default" ? var.kvt_name : local.default_kvt_name
+  resource_group_name = var.rg_name != "default" ? var.rg_name : local.default_rg_name
 }
 
 # read this projects admin group name

--- a/service-app/namings.tf
+++ b/service-app/namings.tf
@@ -3,4 +3,6 @@ locals {
   app_secret_name  = "${var.project}-${var.app_type}-secret"
   app_cert_name    = "${var.project}-${var.app_type}-cert"
   admin_group_name = "${var.project}-admin"
+  default_kvt_name = "kvt-${var.project}-${var.environment}"
+  default_rg_name  = "rg-${var.project}-${var.environment}"
 }

--- a/service-app/namings.tf
+++ b/service-app/namings.tf
@@ -2,7 +2,5 @@ locals {
   app_name         = "${var.project}-${var.app_type}-${var.environment}"
   app_secret_name  = "${var.project}-${var.app_type}-secret"
   app_cert_name    = "${var.project}-${var.app_type}-cert"
-  kvt_name         = "kvt-${var.project}-${var.environment}"
-  rg_name          = "rg-${var.project}-${var.environment}"
   admin_group_name = "${var.project}-admin"
 }

--- a/service-app/providers.tf
+++ b/service-app/providers.tf
@@ -10,9 +10,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {
-  }
-  subscription_id = var.subscription_id
-}

--- a/service-app/readme.md
+++ b/service-app/readme.md
@@ -4,9 +4,8 @@ This module defines a service application in Azure Entra Directory using Terrafo
 
 ## Required Variables
 
-The following variables must be set for the module to work. If the app has no concrete relation to any working project, use a default identity subscription with existing key vault. In our case for example: `subscription_id = "<identity-sub-id>"`, `project = "escorial-id"` and `environment = "main"`.
+The following variables must be set for the module to work. If the app has no concrete relation to any working project, use the default identity subscription with existing key vault. In our case for example: `project = "escorial-id"` and `environment = "main"`. If the subscription where the key vault lies is different from the subscription configured in the provider of your root module, please also define another provider with alias in your root module, set the subscription_id and pass it as this providers module (see example below).
 
-- `subscription_id`: The subscription ID where the project resource group and key vault are located.
 - `project`: The project name this app belongs to.
 - `environment`: The deployment environment or stage (i.e., dev, sbx, tst, prd, main).
 - `app_type`: The type of the app. This is used to build the display name with schema `project-app_type-environment`.
@@ -18,15 +17,19 @@ The following variables must be set for the module to work. If the app has no co
 
 ```hcl
 module "sample_app" {
+  provider = {
+    # define provider in root module and pass here
+    azurerm = azurerm.service_app
+  }
   source = "github.com/drpfleger/terraform/service-app"
 
-  subscription_id        = "<project-subscription-id>"
   project                = "escorial-id"
   environment            = "main"
   app_type               = "sample-app"
   description            = "This is a sample service app"
   is_confidential_client = true
   use_password           = true
+  use_certificate        = false
 }
 ```
 
@@ -43,6 +46,8 @@ The following variables are optional and have default values: Depending on which
 
 The **full list of optional variables** can be found below. Please note that most of these variables are complex types. Refer to the `variables.tf` files of this module to review their structure.
 
+- `kvt_name`: The Name of the keyvault where the password/certificate should be stored. Only set when name differs from naming convention `"kvt-{project}-{environment}"`.
+- `rg_name`: The Name of the resource group where the keyvault is located. Only set when name differs from naming convention `"rg-{project}-{environment}"`.
 - `password_roatation_days`: Days after which a tf apply will auto-rotate the password. Default is `180`.
 - `enabled_for_sign_in`: Whether the service principal is enabled for sign-in. Default is `true`.
 - `assignement_required`: Whether an assignment of User/Group is required to use the app. Default is `true`.

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -52,13 +52,13 @@ variable "use_password" {
 variable "kvt_name" {
   description = "The name of the key vault where the secrets are stored. Set if different from naming convention, the key vault must exist."
   type        = string
-  default     = "default"
+  default     = null
 }
 
 variable "rg_name" {
   description = "The name of the resource group where the key vault is located. Set if different from naming convention, the resource group must exist."
   type        = string
-  default     = "default"
+  default     = null
 }
 
 variable "password_roatation_days" {

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -1,9 +1,4 @@
 # Required variables
-variable "subscription_id" {
-  description = "The subscription ID where the project rg and kvt are located."
-  type        = string
-}
-
 variable "project" {
   description = "The project name this app belongs to."
   type        = string
@@ -35,14 +30,6 @@ variable "is_confidential_client" {
 
   validation {
     condition = (
-      !var.is_confidential_client ||
-      (var.use_certificate && !var.use_password) ||
-      (!var.use_certificate && var.use_password)
-    )
-    error_message = "If 'is_confidential_client' is true, only one of 'use_certificate' or 'use_password' can be true."
-  }
-  validation {
-    condition = (
       var.is_confidential_client ||
       (!var.use_certificate && !var.use_password)
     )
@@ -60,7 +47,20 @@ variable "use_password" {
   type        = bool
 }
 
+
 # Optional variables
+variable "kvt_name" {
+  description = "The name of the key vault where the secrets are stored. If different from naming convention, the key vault must exist."
+  type        = string
+  default     = "kvt-${var.project}-${var.environment}"
+}
+
+variable "rg_name" {
+  description = "The name of the resource group where the key vault is located. If different from naming convention, the resource group must exist."
+  type        = string
+  default     = "rg-${var.project}-${var.environment}"
+}
+
 variable "password_roatation_days" {
   description = "Days after which a tf apply will autorotate the password."
   type        = number

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -50,15 +50,15 @@ variable "use_password" {
 
 # Optional variables
 variable "kvt_name" {
-  description = "The name of the key vault where the secrets are stored. If different from naming convention, the key vault must exist."
+  description = "The name of the key vault where the secrets are stored. Set if different from naming convention, the key vault must exist."
   type        = string
-  default     = "kvt-${var.project}-${var.environment}"
+  default     = "default"
 }
 
 variable "rg_name" {
-  description = "The name of the resource group where the key vault is located. If different from naming convention, the resource group must exist."
+  description = "The name of the resource group where the key vault is located. Set if different from naming convention, the resource group must exist."
   type        = string
-  default     = "rg-${var.project}-${var.environment}"
+  default     = "default"
 }
 
 variable "password_roatation_days" {


### PR DESCRIPTION
- Allow different key vault/rg names
- Pass provider config in root module; remove variable subscription_id
- Remove validation to exclusively use password or certificate; can use both at the same time
- Adjust documentation