### PR TITLE
fix: use object_id instead of resource id

### DIFF
--- a/service-app/rbac.tf
+++ b/service-app/rbac.tf
@@ -5,5 +5,5 @@ resource "azurerm_role_assignment" "main" {
 
   scope                = each.value.scope_id
   role_definition_name = each.value.role_definition_name
-  principal_id         = azuread_service_principal.main.id
+  principal_id         = azuread_service_principal.main.object_id
 }


### PR DESCRIPTION
Address issue #24 to use object_id instead of resource id for rbac assignment of service principal.