### PR TITLE
fix module dependency issue

### DIFF
--- a/service-app/meta.tf
+++ b/service-app/meta.tf
@@ -6,14 +6,6 @@ data "azuread_service_principal" "apis" {
   client_id = each.value.api_client_id
 }
 
-# read the given key vault to store secrets
-# set to default value in naming if not differently set in module call
-# Goal is not having to set values in most cases, only edge cases where naming conventions are not followed
-data "azurerm_key_vault" "main" {
-  name                = var.kvt_name != null ? var.kvt_name : local.default_kvt_name
-  resource_group_name = var.rg_name != null ? var.rg_name : local.default_rg_name
-}
-
 # read this projects admin group name
 data "azuread_group" "project_admin_group" {
   display_name = local.admin_group_name

--- a/service-app/readme.md
+++ b/service-app/readme.md
@@ -30,6 +30,7 @@ module "sample_app" {
   is_confidential_client = true
   use_password           = true
   use_certificate        = false
+  key_vault_id           = <kvt-resource-id>
 }
 ```
 
@@ -46,8 +47,7 @@ The following variables are optional and have default values: Depending on which
 
 The **full list of optional variables** can be found below. Please note that most of these variables are complex types. Refer to the `variables.tf` files of this module to review their structure.
 
-- `kvt_name`: The Name of the keyvault where the password/certificate should be stored. Only set when name differs from naming convention `"kvt-{project}-{environment}"`.
-- `rg_name`: The Name of the resource group where the keyvault is located. Only set when name differs from naming convention `"rg-{project}-{environment}"`.
+- `key_vault_id`: The Resource ID of the keyvault where Secrets should be written to. Required if `is_confidential_client` is `true`.
 - `password_roatation_days`: Days after which a tf apply will auto-rotate the password. Default is `180`.
 - `enabled_for_sign_in`: Whether the service principal is enabled for sign-in. Default is `true`.
 - `assignement_required`: Whether an assignment of User/Group is required to use the app. Default is `true`.

--- a/service-app/secrets.tf
+++ b/service-app/secrets.tf
@@ -21,7 +21,7 @@ resource "time_rotating" "main" {
 resource "azurerm_key_vault_secret" "main" {
   count        = (var.is_confidential_client && var.use_password) ? 1 : 0
   name         = local.app_secret_name
-  key_vault_id = data.azurerm_key_vault.main.id
+  key_vault_id = var.key_vault_id
   value        = azuread_application_password.main[count.index].value
 
   depends_on = [azuread_application_password.main]
@@ -46,7 +46,7 @@ resource "azurerm_key_vault_certificate" "main" {
   count = (var.is_confidential_client && var.use_certificate) ? 1 : 0
 
   name         = local.app_cert_name
-  key_vault_id = data.azurerm_key_vault.main.id
+  key_vault_id = var.key_vault_id
 
   certificate_policy {
     issuer_parameters {

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -47,18 +47,18 @@ variable "use_password" {
   type        = bool
 }
 
-
 # Optional variables
-variable "kvt_name" {
-  description = "The name of the key vault where the secrets are stored. Set if different from naming convention, the key vault must exist."
+variable "key_vault_id" {
+  description = "The Resource ID of the key vault where the secrets should be stored. Required when is_confidential_client is true."
   type        = string
   default     = null
-}
 
-variable "rg_name" {
-  description = "The name of the resource group where the key vault is located. Set if different from naming convention, the resource group must exist."
-  type        = string
-  default     = null
+  validation {
+    condition = (
+      !var.is_confidential_client || var.key_vault_id != null
+    )
+    error_message = "If 'is_confidential_client' is true, key_vault_id cannot be null."
+  }
 }
 
 variable "password_roatation_days" {


### PR DESCRIPTION
Attempting to read the az keyvault if it doesn't exist yet, makes the plan fail. Address this by passing the keyvault_id to the module directly. This should make it possible to call this as a submodule in another module.