### PR TITLE
feat: add outputs for Entra Id application details

### DIFF
--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -7,7 +7,10 @@ output "application_object_id" {
   value       = azuread_application.main.object_id
   description = "The object ID of the Entra Id application."
 }
-
+output "application_client_id" {
+  value       = azuread_application.main.client_id
+  description = "The client ID of the Entra Id application."
+}
 output "application_name" {
   value       = azuread_application.main.display_name
   description = "The display name of the Entra Id application."

--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -1,0 +1,14 @@
+output "application_id" {
+  value       = azuread_application.main.id
+  description = "The ID of the Entra Id application."
+}
+
+output "application_object_id" {
+  value       = azuread_application.main.object_id
+  description = "The object ID of the Entra Id application."
+}
+
+output "application_name" {
+  value       = azuread_application.main.display_name
+  description = "The display name of the Entra Id application."
+}


### PR DESCRIPTION
This pull request adds new outputs to the Terraform configuration for the `service-app` module. These outputs provide key information about the Azure Active Directory (Entra ID) application.

### Additions to Terraform outputs:
* [`service-app/output.tf`](diffhunk://#diff-85d231d105791d5ac75e39bc662999f56b8e01d6700373d2ef2d0b918c0b0403R1-R14): Added three new outputs: `application_id`, `application_object_id`, and `application_name`. These outputs expose the ID, object ID, and display name of the Azure AD application, respectively, along with descriptions for each.