### PR TITLE
Issue/28

### DIFF
--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -12,3 +12,8 @@ output "application_name" {
   value       = azuread_application.main.display_name
   description = "The display name of the Entra Id application."
 }
+
+output "service_principal_id" {
+  value       = azuread_service_principal.main.id
+  description = "The ID of the Entra Id service principal."
+}

--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -1,0 +1,14 @@
+output "application_id" {
+  value       = azuread_application.main.id
+  description = "The ID of the Entra Id application."
+}
+
+output "application_object_id" {
+  value       = azuread_application.main.object_id
+  description = "The object ID of the Entra Id application."
+}
+
+output "application_name" {
+  value       = azuread_application.main.display_name
+  description = "The display name of the Entra Id application."
+}


### PR DESCRIPTION
This pull request introduces new Terraform outputs in the `service-app/output.tf` file to expose key properties of an Entra ID application and its associated service principal. These outputs will make it easier to reference these values in other modules or scripts.

### Added Terraform outputs for Entra ID application and service principal:
* [`service_principal_id`](diffhunk://#diff-85d231d105791d5ac75e39bc662999f56b8e01d6700373d2ef2d0b918c0b0403R1-R22): Outputs the ID of the Entra ID service principal.