### PR TITLE
Make grant own api scopes optional

### DIFF
--- a/service-app/appApiAccess.tf
+++ b/service-app/appApiAccess.tf
@@ -1,7 +1,7 @@
 # "API permissions" in Azure portal
-# API acess for itself
+# API acess for own scopes and roles if grant_own_api_access is true
 resource "azuread_application_api_access" "self" {
-  count = length(local.application_roles) > 0 || length(local.app_scopes) > 0 ? 1 : 0
+  count = var.grant_own_api_access && (length(local.application_roles) > 0 || length(local.app_scopes)) > 0 ? 1 : 0
 
   application_id = azuread_application.main.id
   api_client_id  = azuread_application.main.client_id

--- a/service-app/readme.md
+++ b/service-app/readme.md
@@ -66,6 +66,7 @@ The **full list of optional variables** can be found below. Please note that mos
 - `app_roles`: The App roles defined by the API. Default is an empty map.
 - `api_access`: Define which APIs this app needs to access with which scopes and/or roles. Default is an empty map.
 - `rbac_assignments`: Map of Azure Resources to Role assignments for this Service Principal. Default is an empty map.
+- `grant_own_api_access`: Specify whether this App should be granted API permissions for its own scopes and roles. Default is false.
 - `define_optional_claims`: Whether to use optional claims. Default is `false`.
 - `access_token_claims`: The optional claims to include in the access token. Default is an empty map.
 - `id_token_claims`: The optional claims to include in the id token. Default is an empty map.

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -188,6 +188,12 @@ variable "rbac_assignments" {
   default = {}
 }
 
+variable "grant_own_api_access" {
+  description = "Specify whether this App should be granted API permissions for its own scopes and roles."
+  type        = bool
+  default     = false
+}
+
 # The following optional claims are rarely used.
 variable "define_optional_claims" {
   description = "Whether to use optional claims."


### PR DESCRIPTION
Address issue #33; make own api access optional:
- Add new variable with default false to grant an API App its own scopes and roles.
- Add documentation
- Add logic to only create api access for self when new variable is true and app roles or scopes are defined