### PR TITLE
Add role/scope ID Map to outputs

### DIFF
--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -26,5 +26,9 @@ output "service_principal_id" {
 output "service_principal_object_id" {
   value       = azuread_service_principal.main.object_id
   description = "The object ID of the Entra Id service principal."
+}
 
+output "app_role_ids" {
+  value       = azuread_service_principal.main.app_role_ids
+  description = "The mapping of app role values to IDs of the service principal. Useful for getting role ID by name lookup."
 }

--- a/service-app/output.tf
+++ b/service-app/output.tf
@@ -30,5 +30,10 @@ output "service_principal_object_id" {
 
 output "app_role_ids" {
   value       = azuread_service_principal.main.app_role_ids
-  description = "The mapping of app role values to IDs of the service principal. Useful for getting role ID by name lookup."
+  description = "The mapping of app role values to IDs of this service principal. Useful for getting role ID by name lookup."
+}
+
+output "app_scope_ids" {
+  value       = azuread_service_principal.main.oauth2_permission_scope_ids
+  description = "The mapping of scope values to IDs of this service principal. Useful for getting scope ID by name lookup."
 }


### PR DESCRIPTION
Address #35 to expose a map of Role/ScopeValue -> Role/ScopeID to the Roles and Scopes defined by this application. Useful for accessing the roles and scopes by name when this module is called as a child module.