### PR TITLE
feat: Assign project admin group as subscription owner

### DIFF
--- a/service-app/rbac.tf
+++ b/service-app/rbac.tf
@@ -7,3 +7,11 @@ resource "azurerm_role_assignment" "main" {
   role_definition_name = each.value.role_definition_name
   principal_id         = azuread_service_principal.main.object_id
 }
+
+resource "azurerm_role_assignment" "group_owner" {
+  count = var.group_object_id != null ? 1 : 0
+
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Owner"
+  principal_id         = var.group_object_id
+}

--- a/service-app/variables.tf
+++ b/service-app/variables.tf
@@ -194,6 +194,17 @@ variable "grant_own_api_access" {
   default     = false
 }
 
+variable "group_object_id" {
+  description = "The object ID of the group to assign the Owner role to. If provided, rbac_assignments must be empty."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.group_object_id == null || length(var.rbac_assignments) == 0
+    error_message = "If 'group_object_id' is provided, 'rbac_assignments' must be empty."
+  }
+}
+
 # The following optional claims are rarely used.
 variable "define_optional_claims" {
   description = "Whether to use optional claims."


### PR DESCRIPTION
This PR addresses issue #37 by allowing the assignment of a project admin group as the subscription owner. This is achieved by adding a new `group_object_id` variable and a corresponding role assignment.