### PR TITLE
Assign Az role to project admin group

### DIFF
--- a/main-resource-group/entra.tf
+++ b/main-resource-group/entra.tf
@@ -6,7 +6,7 @@ resource "azuread_group" "admin_group" {
 }
 
 # Assign the created project admin group a role on the subscription level
-resource "azurerm_role_assignment" "admin_group_subscription_owner" {
+resource "azurerm_role_assignment" "admin_group_subscription_role" {
   scope                = "subscriptions/${data.azurerm_client_config.main.subscription_id}"
   role_definition_name = var.admin_group_role
   principal_id         = azuread_group.admin_group.object_id

--- a/main-resource-group/entra.tf
+++ b/main-resource-group/entra.tf
@@ -4,3 +4,10 @@ resource "azuread_group" "admin_group" {
   security_enabled   = true
   assignable_to_role = var.group_assignable_to_role
 }
+
+# Assign the created project admin group a role on the subscription level
+resource "azurerm_role_assignment" "admin_group_subscription_owner" {
+  scope                = "subscriptions/${data.azurerm_client_config.main.subscription_id}"
+  role_definition_name = var.admin_group_role
+  principal_id         = azuread_group.admin_group.object_id
+}

--- a/main-resource-group/entra.tf
+++ b/main-resource-group/entra.tf
@@ -7,7 +7,7 @@ resource "azuread_group" "admin_group" {
 
 # Assign the created project admin group a role on the subscription level
 resource "azurerm_role_assignment" "admin_group_subscription_role" {
-  scope                = "subscriptions/${data.azurerm_client_config.main.subscription_id}"
+  scope                = "/subscriptions/${data.azurerm_client_config.main.subscription_id}"
   role_definition_name = var.admin_group_role
   principal_id         = azuread_group.admin_group.object_id
 }

--- a/main-resource-group/variables.tf
+++ b/main-resource-group/variables.tf
@@ -119,6 +119,12 @@ variable "group_assignable_to_role" {
   default     = false
 }
 
+variable "admin_group_role" {
+  description = "The role name that should be assigned to the created admin group on subscription level"
+  type        = string
+  default     = "Owner"
+}
+
 variable "override_keyvault_name" {
   description = "Override the key vault name"
   type        = string


### PR DESCRIPTION
Address Issue #37 to assign the created project admin group an Azure Role on subscription level.
Default is "Owner" but can be adjusted to any other pre-built role.