### PR TITLE
Issue/70

### DIFF
--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -1,8 +1,6 @@
 # Management Group Policy Module
 
-This module creates a custom Azure Policy definition and assigns it to a management group. It is driven by simple JSON policy files.
-
-The idea: create a folder named after the management group and place policy JSON files inside it. The environment code loads and applies everything automatically.
+This module creates a custom Azure Policy definition at a specified management group scope and assigns it to one or more management groups. It is driven by variables and supports assignment to multiple management groups.
 
 ## How it works
 
@@ -12,25 +10,37 @@ Your environment code loads policy JSON files from:
 management-group-policies/<management-group-name>/*.json
 ```
 
-Each JSON file defines the policy display name, rule and assignment name. The folder name supplies the management group scope.
+Each JSON file defines the policy display name, rule and assignment name. The folder name supplies the management group where the policy is created.
 
 ### Example policy JSON
 
-Here is the structure used by a policy JSON file:
+Here is the structure used by a policy JSON file with the name `enforce-https.json`:
 
 ```json
 {
+	"assignment_management_group_ids": [
+		"landing-zone-management-group",
+		"platform-management-group"
+	],
 	"assignment_name": "root-https",
 	"policy_display_name": "Audit HTTPS Only on App Services",
-	"policy_mode": "Indexed",
+	"policy_mode": "All",
 	"policy_rule": {
 		"if": {
 			"allOf": [
-				{ "field": "type", "equals": "Microsoft.Web/sites" },
-				{ "field": "Microsoft.Web/sites/httpsOnly", "equals": false }
+				{
+					"field": "type",
+					"equals": "Microsoft.Web/sites"
+				},
+				{
+					"field": "Microsoft.Web/sites/httpsOnly",
+					"equals": false
+				}
 			]
 		},
-		"then": { "effect": "audit" }
+		"then": {
+			"effect": "audit"
+		}
 	},
 	"meta_data": {
 		"category": "Security"
@@ -40,6 +50,7 @@ Here is the structure used by a policy JSON file:
 
 Notes:
 
+- `policy_name` is derived from the JSON file name and should be unique in the management group. Use a descriptive name that reflects the policy's purpose.
 - `assignment_name` must be unique in the management group and should stay within 1-24 characters.
 - `policy_mode` is usually `Indexed` or `All`.
 - `policy_rule` must follow the Azure Policy JSON schema.
@@ -68,7 +79,7 @@ provider "azurerm" {
 
 locals {
   # Load all JSON files from the management-group-policies folder
-  # Subfolder names are used to determine the management group scope
+  # Subfolder names are used to determine the management group where the policy is defined
   management_group_policy_files = fileset("${path.module}/management-group-policies", "**/*.json")
 
   # Normalize the JSON files into a map with necessary inputs for the module
@@ -76,8 +87,8 @@ locals {
     for f in local.management_group_policy_files : f => merge(
       jsondecode(file("${path.module}/management-group-policies/${f}")),
       {
-        mg_name     = split("/", f)[0]
-        policy_name = trimsuffix(basename(f), ".json")
+        definition_management_group_name = split("/", f)[0]
+        policy_name                      = trimsuffix(basename(f), ".json")
       }
     )
   }
@@ -94,7 +105,8 @@ module "management_group_policies" {
   policy_rule         = each.value.policy_rule
   meta_data           = each.value.meta_data
   assignment_name     = each.value.assignment_name
-  management_group    = each.value.mg_name
+  management_group    = each.value.assignment_management_group_name
+  definition_management_group = each.value.definition_management_group_name
 }
 ```
 

--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -31,6 +31,9 @@ Here is the structure used by a policy JSON file:
 			]
 		},
 		"then": { "effect": "audit" }
+	},
+	"meta_data": {
+		"category": "Security"
 	}
 }
 ```
@@ -40,6 +43,7 @@ Notes:
 - `assignment_name` must be unique in the management group and should stay within 1-24 characters.
 - `policy_mode` is usually `Indexed` or `All`.
 - `policy_rule` must follow the Azure Policy JSON schema.
+- `meta_data` is optional and can include additional information about the policy definition.
 
 ## Usage
 
@@ -88,6 +92,7 @@ module "management_group_policies" {
   policy_name         = each.value.policy_name
   policy_display_name = each.value.policy_display_name
   policy_rule         = each.value.policy_rule
+  meta_data           = each.value.meta_data
   assignment_name     = each.value.assignment_name
   management_group    = each.value.mg_name
 }

--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -88,7 +88,6 @@ module "management_group_policies" {
   policy_name         = each.value.policy_name
   policy_display_name = each.value.policy_display_name
   policy_rule         = each.value.policy_rule
-  policy_meta_data    = each.value.policy_meta_data
   assignment_name     = each.value.assignment_name
   management_group_id = each.value.mg_name
 }

--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -1,0 +1,109 @@
+# Management Group Policy Module
+
+This module creates a custom Azure Policy definition and assigns it to a management group. It is driven by simple JSON policy files.
+
+The idea: create a folder named after the management group and place policy JSON files inside it. The environment code loads and applies everything automatically.
+
+## How it works
+
+Your environment code loads policy JSON files from:
+
+```
+management-group-policies/<management-group-name>/*.json
+```
+
+Each JSON file defines the policy display name, rule and assignment name. The folder name supplies the management group scope.
+
+### Example policy JSON
+
+Here is the structure used by a policy JSON file:
+
+```json
+{
+	"assignment_name": "root-https",
+	"policy_display_name": "Audit HTTPS Only on App Services",
+	"policy_mode": "Indexed",
+	"policy_rule": {
+		"if": {
+			"allOf": [
+				{ "field": "type", "equals": "Microsoft.Web/sites" },
+				{ "field": "Microsoft.Web/sites/httpsOnly", "equals": false }
+			]
+		},
+		"then": { "effect": "audit" }
+	}
+}
+```
+
+Notes:
+
+- `assignment_name` must be unique in the management group and should stay within 1-24 characters.
+- `policy_mode` is usually `Indexed` or `All`.
+- `policy_rule` must follow the Azure Policy JSON schema.
+
+## Usage
+
+```hcl
+terraform {
+  backend "azurerm" {
+	[...]
+  }
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.65.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  features {}
+}
+
+locals {
+  # Load all JSON files from the management-group-policies folder
+  # Subfolder names are used to determine the management group scope
+  management_group_policy_files = fileset("${path.module}/management-group-policies", "**/*.json")
+
+  # Normalize the JSON files into a map with necessary inputs for the module
+  management_group_policies = {
+    for f in local.management_group_policy_files : f => merge(
+      jsondecode(file("${path.module}/management-group-policies/${f}")),
+      {
+        mg_name     = split("/", f)[0]
+        policy_name = trimsuffix(basename(f), ".json")
+      }
+    )
+  }
+}
+
+
+module "management_group_policies" {
+  for_each = local.management_group_policies
+  source   = "github.com/drpfleger/terraform/policies/managementGroup"
+
+  policy_mode         = each.value.policy_mode
+  policy_name         = each.value.policy_name
+  policy_display_name = each.value.policy_display_name
+  policy_rule         = each.value.policy_rule
+  policy_meta_data    = each.value.policy_meta_data
+  assignment_name     = each.value.assignment_name
+  management_group_id = each.value.mg_name
+}
+
+The environment code is responsible for:
+
+- Discovering the `management-group-policies/<management-group-name>/*.json` files
+- Normalizing JSON into the `local.management_group_policies` map
+- Supplying the `management_group_id` and other inputs
+```
+
+## Quick start
+
+1. Create a folder under `management-group-policies` named after the target management group.
+2. Add one JSON file per policy.
+3. Run Terraform for your policies environment.
+
+That is all you need to do.

--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -91,13 +91,13 @@ module "management_group_policies" {
   assignment_name     = each.value.assignment_name
   management_group_id = each.value.mg_name
 }
+```
 
-The environment code is responsible for:
+## The environment code is responsible for:
 
 - Discovering the `management-group-policies/<management-group-name>/*.json` files
 - Normalizing JSON into the `local.management_group_policies` map
 - Supplying the `management_group_id` and other inputs
-```
 
 ## Quick start
 

--- a/policies/managementGroup/README.md
+++ b/policies/managementGroup/README.md
@@ -89,7 +89,7 @@ module "management_group_policies" {
   policy_display_name = each.value.policy_display_name
   policy_rule         = each.value.policy_rule
   assignment_name     = each.value.assignment_name
-  management_group_id = each.value.mg_name
+  management_group    = each.value.mg_name
 }
 ```
 
@@ -97,7 +97,7 @@ module "management_group_policies" {
 
 - Discovering the `management-group-policies/<management-group-name>/*.json` files
 - Normalizing JSON into the `local.management_group_policies` map
-- Supplying the `management_group_id` and other inputs
+- Supplying the `management_group` and other inputs
 
 ## Quick start
 

--- a/policies/managementGroup/meta.tf
+++ b/policies/managementGroup/meta.tf
@@ -1,3 +1,3 @@
 data "azurerm_management_group" "main" {
-  name = var.management_group_id
+  name = var.management_group
 }

--- a/policies/managementGroup/meta.tf
+++ b/policies/managementGroup/meta.tf
@@ -1,3 +1,8 @@
-data "azurerm_management_group" "main" {
-  name = var.management_group
+data "azurerm_management_group" "definition" {
+  name = var.definition_management_group
+}
+
+data "azurerm_management_group" "assignment" {
+  for_each = toset(var.assignment_management_groups)
+  name     = each.value
 }

--- a/policies/managementGroup/meta.tf
+++ b/policies/managementGroup/meta.tf
@@ -1,0 +1,3 @@
+data "azurerm_management_group" "main" {
+  name = var.management_group_id
+}

--- a/policies/managementGroup/policy.tf
+++ b/policies/managementGroup/policy.tf
@@ -1,0 +1,14 @@
+resource "azurerm_policy_definition" "main" {
+  name                = var.policy_name
+  display_name        = var.policy_display_name
+  mode                = var.policy_mode
+  policy_type         = "Custom"
+  management_group_id = data.azurerm_management_group.main.id
+  policy_rule         = jsonencode(var.policy_rule)
+}
+
+resource "azurerm_management_group_policy_assignment" "example" {
+  name                 = var.assignment_name
+  policy_definition_id = azurerm_policy_definition.main.id
+  management_group_id  = data.azurerm_management_group.main.id
+}

--- a/policies/managementGroup/policy.tf
+++ b/policies/managementGroup/policy.tf
@@ -5,6 +5,7 @@ resource "azurerm_policy_definition" "main" {
   policy_type         = "Custom"
   management_group_id = data.azurerm_management_group.main.id
   policy_rule         = jsonencode(var.policy_rule)
+  metadata            = jsonencode(var.meta_data)
 }
 
 resource "azurerm_management_group_policy_assignment" "example" {

--- a/policies/managementGroup/policy.tf
+++ b/policies/managementGroup/policy.tf
@@ -3,13 +3,15 @@ resource "azurerm_policy_definition" "main" {
   display_name        = var.policy_display_name
   mode                = var.policy_mode
   policy_type         = "Custom"
-  management_group_id = data.azurerm_management_group.main.id
+  management_group_id = data.azurerm_management_group.definition.id
   policy_rule         = jsonencode(var.policy_rule)
   metadata            = jsonencode(var.meta_data)
 }
 
-resource "azurerm_management_group_policy_assignment" "example" {
+resource "azurerm_management_group_policy_assignment" "main" {
+  for_each = data.azurerm_management_group.assignment
+
   name                 = var.assignment_name
   policy_definition_id = azurerm_policy_definition.main.id
-  management_group_id  = data.azurerm_management_group.main.id
+  management_group_id  = each.value.id
 }

--- a/policies/managementGroup/policy.tf
+++ b/policies/managementGroup/policy.tf
@@ -12,6 +12,8 @@ resource "azurerm_management_group_policy_assignment" "main" {
   for_each = data.azurerm_management_group.assignment
 
   name                 = var.assignment_name
+  display_name         = var.assignment_display_name
+  description          = var.assignment_description
   policy_definition_id = azurerm_policy_definition.main.id
   management_group_id  = each.value.id
 }

--- a/policies/managementGroup/providers.tf
+++ b/policies/managementGroup/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.65.0"
+    }
+  }
+}

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -11,6 +11,11 @@ variable "assignment_management_groups" {
 variable "policy_name" {
   description = "Name of the policy definition"
   type        = string
+
+  validation {
+    condition     = length(var.policy_name) >= 1 && length(var.policy_name) <= 64
+    error_message = "policy_name must be between 1 and 24 characters."
+  }
 }
 
 variable "policy_display_name" {
@@ -47,6 +52,23 @@ variable "policy_rule" {
 variable "assignment_name" {
   description = "Name of the policy assignment"
   type        = string
+
+  validation {
+    condition     = length(var.assignment_name) >= 1 && length(var.assignment_name) <= 24
+    error_message = "assignment_name must be between 1 and 24 characters."
+  }
+}
+
+variable "assignment_display_name" {
+  description = "Display name of the policy assignment"
+  type        = string
+  default     = ""
+}
+
+variable "assignment_description" {
+  description = "A description which should be used for this Policy Assignment"
+  type        = string
+  default     = ""
 }
 
 variable "meta_data" {

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -1,5 +1,5 @@
 variable "management_group_id" {
-  description = "ID of the management group to assign policies to"
+  description = "Name (group_id) of the management group to assign policies to (not the full ARM resource ID)"
   type        = string
 }
 

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -1,5 +1,5 @@
-variable "management_group_id" {
-  description = "Name (group_id) of the management group to assign policies to (not the full ARM resource ID)"
+variable "management_group" {
+  description = "Name (group_id) of the management group to assign policies to."
   type        = string
 }
 

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -1,0 +1,50 @@
+variable "management_group_id" {
+  description = "ID of the management group to assign policies to"
+  type        = string
+}
+
+variable "policy_name" {
+  description = "Name of the policy definition"
+  type        = string
+}
+
+variable "policy_display_name" {
+  description = "Display name of the policy definition"
+  type        = string
+}
+
+variable "policy_mode" {
+  description = "All, Indexed. Indexed: Policy is enforced only on resources that support the required properties. All: Policy is enforced on all resources."
+  type        = string
+
+  validation {
+    condition = contains([
+      "All",
+      "Indexed",
+      "Microsoft.ContainerService.Data",
+      "Microsoft.CustomerLockbox.Data",
+      "Microsoft.DataCatalog.Data",
+      "Microsoft.KeyVault.Data",
+      "Microsoft.Kubernetes.Data",
+      "Microsoft.MachineLearningServices.Data",
+      "Microsoft.Network.Data",
+      "Microsoft.Synapse.Data"
+    ], var.policy_mode)
+    error_message = "policy_mode must be one of: All, Indexed, Microsoft.ContainerService.Data, Microsoft.CustomerLockbox.Data, Microsoft.DataCatalog.Data, Microsoft.KeyVault.Data, Microsoft.Kubernetes.Data, Microsoft.MachineLearningServices.Data, Microsoft.Network.Data, Microsoft.Synapse.Data."
+  }
+}
+
+variable "policy_rule" {
+  description = "Policy rule in JSON format (object or string, but typically object)"
+  type        = any
+}
+
+variable "policy_meta_data" {
+  description = "Policy metadata in JSON format (object or string, but typically object)"
+  type        = any
+}
+
+variable "assignment_name" {
+  description = "Name of the policy assignment"
+  type        = string
+}

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -43,3 +43,9 @@ variable "assignment_name" {
   description = "Name of the policy assignment"
   type        = string
 }
+
+variable "meta_data" {
+  description = "Metadata for the policy definition in JSON format as a string."
+  type        = any
+  default     = null
+}

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -1,6 +1,11 @@
-variable "management_group" {
-  description = "Name (group_id) of the management group to assign policies to."
+variable "definition_management_group" {
+  description = "Name (group_id) of the management group the policy is available to (get inherited by child management groups)."
   type        = string
+}
+
+variable "assignment_management_groups" {
+  description = "List of names (group_id) of the management groups to assign policies to."
+  type        = list(string)
 }
 
 variable "policy_name" {

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -39,11 +39,6 @@ variable "policy_rule" {
   type        = any
 }
 
-variable "policy_meta_data" {
-  description = "Policy metadata in JSON format (object or string, but typically object)"
-  type        = any
-}
-
 variable "assignment_name" {
   description = "Name of the policy assignment"
   type        = string

--- a/policies/managementGroup/variables.tf
+++ b/policies/managementGroup/variables.tf
@@ -35,7 +35,7 @@ variable "policy_mode" {
 }
 
 variable "policy_rule" {
-  description = "Policy rule in JSON format (object or string, but typically object)"
+  description = "Policy rule in JSON format as a string. Must follow Azure Policy JSON schema."
   type        = any
 }
 


### PR DESCRIPTION
This pull request updates the management group policy module to support assigning a single policy definition to multiple management groups and clarifies the distinction between where a policy is defined and where it is assigned. The changes improve flexibility, documentation, and input validation for policy assignment.

**Multi-management group assignment & improved configuration:**

* Added support for assigning a single policy definition to multiple management groups by introducing the `assignment_management_groups` variable and updating resources to iterate over all assignments. [[1]](diffhunk://#diff-4440f7d42634b84990bf403ce4afd416e08330afad2d9e039d32bf2856e5f99aL1-R7) [[2]](diffhunk://#diff-6abd56b19f4f0a8aa0b4654151542cdeabbfea31e1a17387252eb83ce0ffc6b7L6-R18) [[3]](diffhunk://#diff-8e8dddb413275d7bcf9d965eedc1f2ce6fee7bf052a2893bc624e7f8a5390395L1-R18)
* Split the concept of the management group where the policy is defined (`definition_management_group`) from those where it is assigned (`assignment_management_groups`), with corresponding variable and data source changes. [[1]](diffhunk://#diff-4440f7d42634b84990bf403ce4afd416e08330afad2d9e039d32bf2856e5f99aL1-R7) [[2]](diffhunk://#diff-8e8dddb413275d7bcf9d965eedc1f2ce6fee7bf052a2893bc624e7f8a5390395L1-R18) [[3]](diffhunk://#diff-5c72d30738eabeb91ffbebc8871bd2cbf359b506fb035dbe8c2066f3c2959603L71-R90) [[4]](diffhunk://#diff-5c72d30738eabeb91ffbebc8871bd2cbf359b506fb035dbe8c2066f3c2959603L97-R109)

**Documentation and input validation:**

* Updated the `README.md` to clarify the new assignment model, including an updated example policy JSON structure and improved explanations of variables and expected file organization. [[1]](diffhunk://#diff-5c72d30738eabeb91ffbebc8871bd2cbf359b506fb035dbe8c2066f3c2959603L3-R3) [[2]](diffhunk://#diff-5c72d30738eabeb91ffbebc8871bd2cbf359b506fb035dbe8c2066f3c2959603L15-R43) [[3]](diffhunk://#diff-5c72d30738eabeb91ffbebc8871bd2cbf359b506fb035dbe8c2066f3c2959603R53)
* Added input validation for `policy_name` and `assignment_name` variables to ensure they meet Azure requirements for length. [[1]](diffhunk://#diff-8e8dddb413275d7bcf9d965eedc1f2ce6fee7bf052a2893bc624e7f8a5390395L1-R18) [[2]](diffhunk://#diff-8e8dddb413275d7bcf9d965eedc1f2ce6fee7bf052a2893bc624e7f8a5390395R55-R71)

**Additional assignment metadata:**

* Introduced new variables for `assignment_display_name` and `assignment_description` to allow more descriptive policy assignments. [[1]](diffhunk://#diff-6abd56b19f4f0a8aa0b4654151542cdeabbfea31e1a17387252eb83ce0ffc6b7L6-R18) [[2]](diffhunk://#diff-8e8dddb413275d7bcf9d965eedc1f2ce6fee7bf052a2893bc624e7f8a5390395R55-R71)